### PR TITLE
Bugfixes and some improvements

### DIFF
--- a/src/fy.rs
+++ b/src/fy.rs
@@ -8,7 +8,7 @@ pub struct FisherYates {
 }
 
 impl FisherYates {
-    pub fn shuffle<T>(&mut self, data: &mut Vec<T>) {
+    pub fn shuffle<T>(&mut self, data: &mut [T]) {
         for i in 1..data.len() {
             let j = self.gen_range(i);
             data.swap(i, j);


### PR DESCRIPTION
1. Fix `gen_range` for u16, i8, i16, i32 giving incorrect results (rand() result was being divided by their type MAX values instead of `u32::MAX`).
2. Resolve https://github.com/not-fl3/quad-rand/issues/9  (Becasue of this issue ChooseRandom::choose could panic).
3. Replace individual implementations of RandomRange with macro.
4. Make ChooseRandom work with slice instead of Vec.