### PR TITLE
Support generator instances

### DIFF
--- a/examples/basic_with_state.rs
+++ b/examples/basic_with_state.rs
@@ -1,0 +1,20 @@
+use quad_rand as qrand;
+
+fn main() {
+    // seed random
+    let randomness = qrand::RandGenerator::new();
+    randomness.srand(12345);
+
+    // get random number from 0 to u32::MAX
+    let x = randomness.rand();
+
+    // get random number from given range
+    let x = randomness.gen_range(0., 1.);
+    assert!(x >= 0. && x < 1.);
+    println!("x={}", x);
+
+    // gen_range works for most of standard number types
+    let x: u8 = randomness.gen_range(64, 128);
+    assert!(x >= 64 && x < 128);
+    println!("x={}", x);
+}

--- a/examples/compat_with_state.rs
+++ b/examples/compat_with_state.rs
@@ -1,0 +1,13 @@
+use quad_rand::compat::QuadRandWithState;
+use rand::seq::SliceRandom;
+
+fn main() {
+    let randomness = quad_rand::RandGenerator::new();
+
+    let mut vec = vec![1, 2, 3, 4, 5, 6];
+    println!("ordered: {:?}", vec);
+
+    // QuadRand is rand::RngCore implementation, allowing to use all the cool stuff from rand
+    vec.shuffle(&mut QuadRandWithState(&randomness));
+    println!("shuffled: {:?}", vec);
+}

--- a/src/fy.rs
+++ b/src/fy.rs
@@ -1,6 +1,8 @@
 //! Implementation of Fisher-Yates algorithm.
 //! This is modified version of https://github.com/adambudziak/shuffle/blob/master/src/fy.rs
 
+use crate::RandGenerator;
+
 /// Implementation of Fisher-Yates algorithm.
 #[derive(Debug, Default)]
 pub struct FisherYates {
@@ -8,22 +10,25 @@ pub struct FisherYates {
 }
 
 impl FisherYates {
-    pub fn shuffle<T>(&mut self, data: &mut [T]) {
+    // pub fn shuffle<T>(&mut self, data: &mut [T]) {
+    //     self.shuffle_with_state(&GLOBAL_STATE, data);
+    // }
+    pub fn shuffle_with_state<T>(&mut self, state: &RandGenerator, data: &mut [T]) {
         for i in 1..data.len() {
-            let j = self.gen_range(i);
+            let j = self.gen_range(state, i);
             data.swap(i, j);
         }
     }
 }
 
 impl FisherYates {
-    fn gen_range(&mut self, top: usize) -> usize {
+    fn gen_range(&mut self, state: &RandGenerator, top: usize) -> usize {
         const USIZE_BYTES: usize = std::mem::size_of::<usize>();
         let bit_width = USIZE_BYTES * 8 - top.leading_zeros() as usize;
         let byte_count = (bit_width - 1) / 8 + 1;
         loop {
             for i in 0..byte_count {
-                self.buffer[i] = crate::gen_range(0, 255);
+                self.buffer[i] = state.gen_range(0, 255);
             }
             let result = usize::from_le_bytes(self.buffer);
             let result = result & ((1 << bit_width) - 1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,55 +5,89 @@ mod fy;
 const DEFAULT_INC: u64 = 1442695040888963407;
 const MULTIPLIER: u64 = 6364136223846793005;
 
-static STATE: AtomicU64 = AtomicU64::new(0);
+pub struct RandGenerator {
+    state: AtomicU64,
+}
+
+impl RandGenerator {
+    pub const fn new() -> Self {
+        Self {
+            state: AtomicU64::new(0),
+        }
+    }
+    pub fn srand(&self, seed: u64) {
+        self.state.store(0, Ordering::Relaxed);
+        self.rand();
+        let oldstate = self.state.load(Ordering::Relaxed);
+        self.state
+            .store(oldstate.wrapping_add(seed), Ordering::Relaxed);
+        self.rand();
+    }
+    pub fn rand(&self) -> u32 {
+        let oldstate: u64 = self.state.load(Ordering::Relaxed);
+        self.state.store(
+            oldstate.wrapping_mul(MULTIPLIER).wrapping_add(DEFAULT_INC),
+            Ordering::Relaxed,
+        );
+        let xorshifted: u32 = (((oldstate >> 18) ^ oldstate) >> 27) as u32;
+        let rot: u32 = (oldstate >> 59) as u32;
+        xorshifted.rotate_right(rot)
+    }
+    #[inline]
+    pub fn gen_range<T>(&self, low: T, high: T) -> T
+    where
+        T: RandomRange,
+    {
+        T::gen_range_with_state(self, low, high)
+    }
+}
+
+static GLOBAL_STATE: RandGenerator = RandGenerator::new();
 
 /// Seeds the pseudo-random number generator used by rand()
 /// with the value seed.
+#[inline]
 pub fn srand(seed: u64) {
-    STATE.store(0, Ordering::Relaxed);
-    rand();
-    let oldstate = STATE.load(Ordering::Relaxed);
-    STATE.store(oldstate.wrapping_add(seed), Ordering::Relaxed);
-    rand();
+    GLOBAL_STATE.srand(seed);
 }
 
 /// Returns a pseudo-random number in the range of 0 to u32::MAX.
+#[inline]
 pub fn rand() -> u32 {
-    let oldstate: u64 = STATE.load(Ordering::Relaxed);
-    STATE.store(
-        oldstate.wrapping_mul(MULTIPLIER).wrapping_add(DEFAULT_INC),
-        Ordering::Relaxed,
-    );
-    let xorshifted: u32 = (((oldstate >> 18) ^ oldstate) >> 27) as u32;
-    let rot: u32 = (oldstate >> 59) as u32;
-    xorshifted.rotate_right(rot)
+    GLOBAL_STATE.rand()
 }
 
 pub trait RandomRange {
     fn gen_range(low: Self, high: Self) -> Self;
+    fn gen_range_with_state(state: &RandGenerator, low: Self, high: Self) -> Self;
 }
 
 macro_rules! impl_random_range{
-  ($($ty:ty),*,)=>{
-    $(
-      impl RandomRange for $ty{
-        #[inline]
-        fn gen_range(low: Self, high: Self) -> Self {
-          let r = rand() as f64 / (u32::MAX as f64 + 1.0);
-          let r = low as f64 + (high as f64 - low as f64) * r;
-          r as Self
-        }
-      }
-    )*
-  }
+    ($($ty:ty),*,)=>{
+        $(
+            impl RandomRange for $ty{
+                #[inline]
+                fn gen_range(low: Self, high: Self) -> Self{
+                    Self::gen_range_with_state(&GLOBAL_STATE, low, high)
+                }
+                #[inline]
+                fn gen_range_with_state(gen: &RandGenerator, low: Self, high: Self) -> Self {
+                    let r = gen.rand() as f64 / (u32::MAX as f64 + 1.0);
+                    let r = low as f64 + (high as f64 - low as f64) * r;
+                    r as Self
+                }
+            }
+        )*
+    }
 }
 impl_random_range!(f32, f64, u8, u16, u32, u64, usize, i8, i16, i32, i64, isize,);
 
+#[inline]
 pub fn gen_range<T>(low: T, high: T) -> T
 where
     T: RandomRange,
 {
-    T::gen_range(low, high)
+    GLOBAL_STATE.gen_range(low, high)
 }
 
 pub struct SliceChooseIter<'a, T> {
@@ -64,41 +98,72 @@ pub struct SliceChooseIter<'a, T> {
 impl<'a, T> Iterator for SliceChooseIter<'a, T> {
     type Item = &'a T;
 
+    #[inline]
     fn next(&mut self) -> Option<&'a T> {
         self.indices.next().map(|ix| &self.source[ix])
     }
 }
 
 pub trait ChooseRandom<T> {
-    fn shuffle(&mut self);
-    fn choose(&self) -> Option<&T>;
-    fn choose_mut(&mut self) -> Option<&mut T>;
-    fn choose_multiple(&self, _amount: usize) -> SliceChooseIter<T>;
+    #[inline]
+    fn shuffle(&mut self) {
+        self.shuffle_with_state(&GLOBAL_STATE)
+    }
+    #[inline]
+    fn choose(&self) -> Option<&T> {
+        self.choose_with_state(&GLOBAL_STATE)
+    }
+    #[inline]
+    fn choose_mut(&mut self) -> Option<&mut T> {
+        self.choose_mut_with_state(&GLOBAL_STATE)
+    }
+    #[inline]
+    fn choose_multiple(&self, amount: usize) -> SliceChooseIter<T> {
+        self.choose_multiple_with_state(&GLOBAL_STATE, amount)
+    }
+
+    fn shuffle_with_state(&mut self, state: &RandGenerator);
+    fn choose_with_state(&self, state: &RandGenerator) -> Option<&T>;
+    fn choose_mut_with_state(&mut self, state: &RandGenerator) -> Option<&mut T>;
+    fn choose_multiple_with_state(
+        &self,
+        state: &RandGenerator,
+        _amount: usize,
+    ) -> SliceChooseIter<T>;
 }
 
 impl<T> ChooseRandom<T> for [T] {
-    fn shuffle(&mut self) {
+    #[inline]
+    fn shuffle_with_state(&mut self, state: &RandGenerator) {
         let mut fy = fy::FisherYates::default();
 
-        fy.shuffle(self);
+        fy.shuffle_with_state(state, self);
     }
 
-    fn choose(&self) -> Option<&T> {
-        let ix = gen_range(0, self.len());
+    #[inline]
+    fn choose_with_state(&self, state: &RandGenerator) -> Option<&T> {
+        let ix = state.gen_range(0, self.len());
         self.get(ix)
     }
 
-    fn choose_mut(&mut self) -> Option<&mut T> {
-        let ix = gen_range(0, self.len());
+    #[inline]
+    fn choose_mut_with_state(&mut self, state: &RandGenerator) -> Option<&mut T> {
+        let ix = state.gen_range(0, self.len());
         self.get_mut(ix)
     }
 
-    fn choose_multiple(&self, amount: usize) -> SliceChooseIter<T> {
+    #[inline]
+    fn choose_multiple_with_state(
+        &self,
+        state: &RandGenerator,
+        amount: usize,
+    ) -> SliceChooseIter<T> {
         let mut indices = (0..self.len())
             .enumerate()
             .map(|(i, _)| i)
             .collect::<Vec<usize>>();
 
+        indices.shuffle_with_state(state);
         indices.resize(amount, 0);
 
         SliceChooseIter {
@@ -110,25 +175,53 @@ impl<T> ChooseRandom<T> for [T] {
 
 #[cfg(feature = "rand")]
 pub mod compat {
-    pub struct QuadRand;
+    pub struct QuadRandWithState<'a>(pub &'a crate::RandGenerator);
 
-    impl rand::RngCore for QuadRand {
+    impl<'a> rand::RngCore for QuadRandWithState<'a> {
+        #[inline]
         fn next_u32(&mut self) -> u32 {
-            crate::gen_range(0, std::u32::MAX)
+            self.0.gen_range(0, std::u32::MAX)
         }
 
+        #[inline]
         fn next_u64(&mut self) -> u64 {
-            crate::gen_range(0, std::u64::MAX)
+            self.0.gen_range(0, std::u64::MAX)
         }
 
+        #[inline]
         fn fill_bytes(&mut self, dest: &mut [u8]) {
             for i in 0..dest.len() {
-                dest[i] = crate::gen_range(0, 255)
+                dest[i] = self.0.gen_range(0, 255)
             }
         }
 
+        #[inline]
         fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
             Ok(self.fill_bytes(dest))
+        }
+    }
+
+    pub struct QuadRand;
+
+    impl rand::RngCore for QuadRand {
+        #[inline]
+        fn next_u32(&mut self) -> u32 {
+            QuadRandWithState(&crate::GLOBAL_STATE).next_u32()
+        }
+
+        #[inline]
+        fn next_u64(&mut self) -> u64 {
+            QuadRandWithState(&crate::GLOBAL_STATE).next_u64()
+        }
+
+        #[inline]
+        fn fill_bytes(&mut self, dest: &mut [u8]) {
+            QuadRandWithState(&crate::GLOBAL_STATE).fill_bytes(dest)
+        }
+
+        #[inline]
+        fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
+            QuadRandWithState(&crate::GLOBAL_STATE).try_fill_bytes(dest)
         }
     }
 }


### PR DESCRIPTION
Users can now have independant instances of randomness. All existing functionality can now be used with instanced generators. This is non-breaking change, all existing apis will remain the same.

Examples
(For full examples see `basic_with_state.rs` and `compat_with_state.rs`):
```rust
let randomness = RandGenerator::new();
randomness.srand(12345);
let x = randomness.gen_range(0.0,1.0);

let mut vec = vec![1, 2, 3, 4, 5, 6];

vec.shuffle_with_state(&randomness);

// Example for `rand` crate compatibility

use rand::seq::SliceRandom;
vec.shuffle(&mut QuadRandWithState(&randomness));
```

Additionaly fixed choose_multiple by adding a call to shuffle.

-----

PS. I dont really like  the "_with_state" postfix, but  couldn't think of anything better to use.