### PR TITLE
bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quad-rand"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["not-fl3 <not.fl3@gmail.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
There are several bugs already fixed in the git version of the crate that are not yet on crates.io, which would just need a new relased patch version.

Closes #12.
Closes #13. 
Closes not-fl3/macroquad#700.