### PR TITLE
make the crate `#![no_std]` compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,12 @@ license = "MIT"
 homepage = "https://github.com/not-fl3/quad-rand"
 repository = "https://github.com/not-fl3/quad-rand"
 description = """
-Pseudo random implementation with std atomics.
+Pseudo random implementation with core atomics.
 """
-readme="README.md"
+readme = "README.md"
 
 [dependencies]
-rand = {version = "0.8", optional = true}
+rand = { version = "0.8", optional = true }
 
 [[example]]
 name = "compat"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 `quad-rand` implements pseudo-random generator http://www.pcg-random.org/download.html based on rust atomics. 
 
-Compatible with wasm and any other rust target with std.
+Compatible with wasm and also no-std compatible.
 
 Basic usage, no dependencies involved:
 ```rust

--- a/src/fy.rs
+++ b/src/fy.rs
@@ -1,10 +1,12 @@
 //! Implementation of Fisher-Yates algorithm.
 //! This is modified version of https://github.com/adambudziak/shuffle/blob/master/src/fy.rs
 
+use core::mem::size_of;
+
 /// Implementation of Fisher-Yates algorithm.
 #[derive(Debug, Default)]
 pub struct FisherYates {
-    buffer: [u8; std::mem::size_of::<usize>()],
+    buffer: [u8; size_of::<usize>()],
 }
 
 impl FisherYates {
@@ -18,7 +20,7 @@ impl FisherYates {
 
 impl FisherYates {
     fn gen_range(&mut self, top: usize) -> usize {
-        const USIZE_BYTES: usize = std::mem::size_of::<usize>();
+        const USIZE_BYTES: usize = size_of::<usize>();
         let bit_width = USIZE_BYTES * 8 - top.leading_zeros() as usize;
         let byte_count = (bit_width - 1) / 8 + 1;
         loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,8 @@
-use std::sync::atomic::{AtomicU64, Ordering};
+#![no_std]
+extern crate alloc;
+
+use alloc::vec::Vec;
+use core::sync::atomic::{AtomicU64, Ordering};
 
 mod fy;
 
@@ -58,7 +62,7 @@ where
 
 pub struct SliceChooseIter<'a, T> {
     source: &'a [T],
-    indices: std::vec::IntoIter<usize>,
+    indices: alloc::vec::IntoIter<usize>,
 }
 
 impl<'a, T> Iterator for SliceChooseIter<'a, T> {
@@ -114,11 +118,11 @@ pub mod compat {
 
     impl rand::RngCore for QuadRand {
         fn next_u32(&mut self) -> u32 {
-            crate::gen_range(0, std::u32::MAX)
+            crate::gen_range(0, u32::MAX)
         }
 
         fn next_u64(&mut self) -> u64 {
-            crate::gen_range(0, std::u64::MAX)
+            crate::gen_range(0, u64::MAX)
         }
 
         fn fill_bytes(&mut self, dest: &mut [u8]) {


### PR DESCRIPTION
All the items from `std` used in this crate can be imported from `core` or `alloc`, so we can add `#![no_std]` to increase the amount of supported targets without losing any features.