### PR TITLE
Bump version to 0.2.3 for generator instances and no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quad-rand"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["not-fl3 <not.fl3@gmail.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
Includes changes since v0.2.3 like the generator instances and no_std compatability, I mostly just want to be able to use this in my own game with the crates.io version so I can avoid having to reseed my generator every tick to keep my sim deterministic 👀

Should probably also close #11