### PR TITLE
rewrite `gen_range` to take any range type instead of `low`, `high`

### DIFF
--- a/examples/all_range_kinds.rs
+++ b/examples/all_range_kinds.rs
@@ -1,0 +1,25 @@
+use quad_rand as qrand;
+
+// all kinds of range types can be used
+fn main() {
+    // seed random
+    qrand::srand(12345);
+
+    let r = qrand::gen_range(4..7);
+    assert!(r >= 4 && r < 7);
+
+    let r = qrand::gen_range(4..=7);
+    assert!(r >= 4 && r <= 7);
+
+    let r = qrand::gen_range(252u8..);
+    assert!(r >= 252);
+
+    let r: i16 = quad_rand::gen_range(..);
+    println!("r={}", r);
+
+    let r = qrand::gen_range(..3);
+    assert!(r < 3);
+
+    let r = qrand::gen_range(1.0..=2.0);
+    assert!(r >= 1.0 && r <= 2.0);
+}

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -8,12 +8,12 @@ fn main() {
     let x = qrand::rand();
 
     // get random number from given range
-    let x = qrand::gen_range(0., 1.);
+    let x = qrand::gen_range(0. ..1.);
     assert!(x >= 0. && x < 1.);
     println!("x={}", x);
 
     // gen_range works for most of standard number types
-    let x: u8 = qrand::gen_range(64, 128);
+    let x: u8 = qrand::gen_range(64..128);
     assert!(x >= 64 && x < 128);
     println!("x={}", x);
 }

--- a/examples/basic_with_state.rs
+++ b/examples/basic_with_state.rs
@@ -9,12 +9,12 @@ fn main() {
     let x = randomness.rand();
 
     // get random number from given range
-    let x = randomness.gen_range(0., 1.);
+    let x = randomness.gen_range(0. ..1.);
     assert!(x >= 0. && x < 1.);
     println!("x={}", x);
 
     // gen_range works for most of standard number types
-    let x: u8 = randomness.gen_range(64, 128);
+    let x: u8 = randomness.gen_range(64..128);
     assert!(x >= 64 && x < 128);
     println!("x={}", x);
 }

--- a/src/fy.rs
+++ b/src/fy.rs
@@ -26,7 +26,7 @@ impl FisherYates {
         let byte_count = (bit_width - 1) / 8 + 1;
         loop {
             for i in 0..byte_count {
-                self.buffer[i] = state.gen_range(0, 255);
+                self.buffer[i] = state.gen_range(0..=255);
             }
             let result = usize::from_le_bytes(self.buffer);
             let result = result & ((1 << bit_width) - 1);


### PR DESCRIPTION
**This is a breaking change and requires the next released version to be 0.3.0.**

This PR rewrites `gen_range` and `gen_range_with_state` to take one argument that is any range type (`impl RangeBounds<T>`)  instead of two arguments `low` and `high`. It also adds an example to show that all core range types are supported.

This has several advantages:
1. Right now, there is no easy way to get "a random byte" / "a random `u8`", since `quad_rand::gen_range(0, 255)` is never going to return 255, as this program demonstrates:
```rust
fn main() {
    for _ in 0..1_000_000 {
        let r: u8 = quad_rand::gen_range(0, 255);
        assert!(r != 255);
    }
}
```
With this PR, one would simply write `quad_rand::gen_range(0..=255)` (or just `quad_rand::gen_range(..)` as long as the type of the range elements can be inferred) and get an `u8` that can be 255 too.
2. It is currently not always clear to a user whether the `high` argument is inclusive or exclusive, which has caused confusion and bugs in the past (e.g. #13). The new API solves that problem by making inclusive ranges explicitly `low..=high` and exclusive ones `low..high`.

It is also more consistent with other ecosystem crates like `rand`.

Fixes https://github.com/not-fl3/macroquad/issues/403.