### PR TITLE
Use portable-atomic on platforms without u64 atomics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ readme = "README.md"
 [dependencies]
 rand = { version = "0.8", optional = true }
 
+[target.'cfg(not(target_has_atomic = "64"))'.dependencies]
+portable-atomic = "1"
+
 [[example]]
 name = "compat"
 path = "examples/compat.rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,12 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
-use core::sync::atomic::{AtomicU64, Ordering};
+use core::sync::atomic::Ordering;
+
+#[cfg(target_has_atomic = "64")]
+use core::sync::atomic::AtomicU64;
+#[cfg(not(target_has_atomic = "64"))]
+use portable_atomic::AtomicU64;
 
 mod fy;
 


### PR DESCRIPTION
This has been tested on `powerpc-unknown-linux-gnu`, which supports atomics only up to `u32`.  Without this commit, building quad-rand would fail with:
```
error[E0432]: unresolved import `core::sync::atomic::AtomicU64`
 --> src/lib.rs:5:26
  |
5 | use core::sync::atomic::{AtomicU64, Ordering};
  |                          ^^^^^^^^^
  |                          |
  |                          no `AtomicU64` in `sync::atomic`
  |                          help: a similar name exists in the module: `AtomicU32`
```